### PR TITLE
Prepare 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.4.0 – 2025-07-28
+
+### Changed
+
+- Bump max Nextcloud version to 28 @julien-nc
+- Use Psalm 6 @julien-nc
+- Update composer dependencies @julien-nc
+
+### Fixed
+
+- Style issues in admin and personal settings, wrong title alignment @julien-nc
+- Fix link to google console @julien-nc
+
 ## 0.3.1 – 2024-11-07
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@ Set an API key in the Administration settings -> Connected Accounts -> Youtube I
 
 Note: The search and smart picker functionality is disabled by default. Users can opt-in to enable them from their respective settings.
 ]]></description>
-	<version>0.3.1</version>
+	<version>0.4.0</version>
 	<licence>agpl</licence>
 	<author>Julius Härtl</author>
 	<namespace>IntegrationYoutube</namespace>


### PR DESCRIPTION
### Changed

- Bump max Nextcloud version to 28 @julien-nc
- Use Psalm 6 @julien-nc
- Update composer dependencies @julien-nc

### Fixed

- Style issues in admin and personal settings, wrong title alignment @julien-nc
- Fix link to google console @julien-nc