### PR TITLE
0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 # Change Log
@@ -7,6 +7,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## 0.7.0 - 2026-04-16
+
+### Added
+- moderize personal and admin settings ([#54](https://github.com/nextcloud/integration_youtube/pull/54)) @kyteinsky
+
+### Changed
+- Adapted spelling of "API" ([#52](https://github.com/nextcloud/integration_youtube/pull/52)) @rakekniven
+- maintenance updates ([#55](https://github.com/nextcloud/integration_youtube/pull/55)) @kyteinsky
+- bump max supported NC version to 34
+
 
 ## 0.6.1 - 2025-11-17
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@ Set an API key in the Administration settings -> Connected Accounts -> YouTube I
 
 Note: The search and smart picker functionality is disabled by default. Users can opt-in to enable them from their respective settings.
 ]]></description>
-	<version>0.6.1</version>
+	<version>0.7.0</version>
 	<licence>agpl</licence>
 	<author>Julius Härtl</author>
 	<namespace>IntegrationYoutube</namespace>
@@ -22,7 +22,7 @@ Note: The search and smart picker functionality is disabled by default. Users ca
 	<screenshot>https://raw.githubusercontent.com/nextcloud/integration_youtube/main/img/screenshot2.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/integration_youtube/main/img/screenshot3.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="32" max-version="33"/>
+		<nextcloud min-version="32" max-version="34"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\IntegrationYoutube\Settings\Admin</admin>

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -19,6 +19,28 @@ release_agent:
   - author: "^dependabot\\[bot\\]$"
   - message: "^chore\\(changelog\\):"
 entries:
+- version: 0.7.0
+  release_date: '2026-04-16'
+  sections:
+  - name: Added
+    items:
+    - text: moderize personal and admin settings
+      authors:
+      - kyteinsky
+      issue_number: 54
+  - name: Changed
+    items:
+    - text: Adapted spelling of "API"
+      authors:
+      - rakekniven
+      issue_number: 52
+    - text: maintenance updates
+      authors:
+      - kyteinsky
+      issue_number: 55
+    - text: bump max supported NC version to 34
+      authors: []
+      issue_number:
 - version: 0.6.1
   release_date: '2025-11-17'
   sections:


### PR DESCRIPTION
## 0.7.0 - 2026-04-16

### Added
- moderize personal and admin settings ([#54](https://github.com/nextcloud/integration_youtube/pull/54)) @kyteinsky

### Changed
- Adapted spelling of "API" ([#52](https://github.com/nextcloud/integration_youtube/pull/52)) @rakekniven
- maintenance updates ([#55](https://github.com/nextcloud/integration_youtube/pull/55)) @kyteinsky
- bump max supported NC version to 34
